### PR TITLE
Align all three projects at 1.1.0

### DIFF
--- a/ShivendraConsoleApp/ShivendraConsoleApp.csproj
+++ b/ShivendraConsoleApp/ShivendraConsoleApp.csproj
@@ -7,9 +7,8 @@
     <Nullable>enable</Nullable>
 	  <WarningLevel>9999</WarningLevel>
 	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-	  <!-- Release version. Bump this before tagging a release so the tag, the assembly
-	       and the log-file header all agree. Last released tag: v1.0.4. -->
-	  <Version>1.0.5</Version>
+	  <!-- Kept in step with ShivendraGst.Core and ShivendraGstWinApp. -->
+	  <Version>1.1.0</Version>
   </PropertyGroup>
 
   <!-- The scraping engine, logger and config live in the shared Core library, which the

--- a/ShivendraGst.Core/ShivendraGst.Core.csproj
+++ b/ShivendraGst.Core/ShivendraGst.Core.csproj
@@ -6,7 +6,9 @@
     <Nullable>enable</Nullable>
     <WarningLevel>9999</WarningLevel>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>1.0.0</Version>
+    <!-- All three projects ship together and share this number. Bump them together
+         before tagging a release so the tag, the assemblies and the log header agree. -->
+    <Version>1.1.0</Version>
     <!-- Source is grouped into folders (Configuration, Diagnostics, Abstractions,
          Scraping, Io, Resources) but everything stays in the single ShivendraGst.Core
          namespace, so front ends need only one using. -->

--- a/ShivendraGstWinApp/ShivendraGstWinApp.csproj
+++ b/ShivendraGstWinApp/ShivendraGstWinApp.csproj
@@ -8,7 +8,8 @@
     <Nullable>enable</Nullable>
     <WarningLevel>9999</WarningLevel>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-    <Version>1.0.0</Version>
+    <!-- Kept in step with ShivendraGst.Core and ShivendraConsoleApp. -->
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Core and WinForms were on 1.0.0 and the console app on 1.0.5, so the solution had no single number to refer to. They ship together, and the log header reports Core's version regardless of which front end wrote it, so a shared number is the one that means something.

Minor rather than patch: dropping the Python runtime dependency, reading .xls with ExcelDataReader, prerequisite checking and folder-input batching are features, not fixes.